### PR TITLE
Add getSampleRate()

### DIFF
--- a/rubberband/RubberBandStretcher.h
+++ b/rubberband/RubberBandStretcher.h
@@ -701,6 +701,11 @@ public:
     size_t getChannelCount() const;
 
     /**
+     * Return the sample rate this stretcher was constructed with.
+     */
+    size_t getSampleRate() const;
+
+    /**
      * Force the stretcher to calculate a stretch profile.  Normally
      * this happens automatically for the first process() call in
      * offline mode.

--- a/src/RubberBandStretcher.cpp
+++ b/src/RubberBandStretcher.cpp
@@ -201,6 +201,12 @@ RubberBandStretcher::getChannelCount() const
     return m_d->getChannelCount();
 }
 
+size_t
+RubberBandStretcher::getSampleRate() const
+{
+    return m_d->getSampleRate();
+}
+
 void
 RubberBandStretcher::calculateStretch()
 {

--- a/src/StretcherImpl.h
+++ b/src/StretcherImpl.h
@@ -102,7 +102,11 @@ public:
     size_t getChannelCount() const {
         return m_channels;
     }
-    
+
+    size_t getSampleRate() const {
+        return m_sampleRate;
+    }
+
     void calculateStretch();
 
     void setDebugLevel(int level);


### PR DESCRIPTION
This is a convenience function to allow applications to easily know
what sample rate the stretcher was initalized with to check if it
needs to be recreated.