### PR TITLE
Change Module Filename of Android Makefile

### DIFF
--- a/com/breakfastquay/rubberband/RubberBandStretcher.java
+++ b/com/breakfastquay/rubberband/RubberBandStretcher.java
@@ -124,7 +124,7 @@ public class RubberBandStretcher
     public static final int PercussiveOptions          = 0x00102000;
 
     static {
-	System.loadLibrary("rubberband-jni");
+	System.loadLibrary("rubberband");
     }
 };
 

--- a/otherbuilds/Android.mk
+++ b/otherbuilds/Android.mk
@@ -1,6 +1,6 @@
 
 LOCAL_MODULE := rubberband
-LOCAL_MODULE_FILENAME := librubberband-jni
+LOCAL_MODULE_FILENAME := librubberband
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/rubberband $(LOCAL_PATH)/rubberband/src
 


### PR DESCRIPTION
Setting LOCAL_MODULE_FILENAME=librubberband-jni raises error:  
`make: *** No rule to make target 'rubberband-jni'.  Stop.`  
because (it seems that) Android Studio refers to LOCAL_MODULE_FILENAME when building ndk.  
Module name is rubberband (not rubberband-jni), so setting LOCAL_MODULE_FILENAME to librubberband solves error and also makes no ambiguity.  

Please consider this pull request.