### PR TITLE
Fixed buffer overflow crash in StretcherImpl

### DIFF
--- a/src/StretcherImpl.cpp
+++ b/src/StretcherImpl.cpp
@@ -832,6 +832,7 @@ RubberBandStretcher::Impl::reconfigure()
 
     if (m_fftSize != prevFftSize) {
         m_phaseResetAudioCurve->setFftSize(m_fftSize);
+        m_silentAudioCurve->setFftSize(m_fftSize);
     }
 }
 


### PR DESCRIPTION
m_silentAudioCurve’s FFT size member wasn’t being updated, causing a buffer overflow