### PR TITLE
Add include_directories to rubberband_static_dep

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -422,6 +422,7 @@ rubberband_static = static_library(
 
 rubberband_static_dep = declare_dependency(
   link_with: rubberband_static,
+  include_directories : include_directories('rubberband')
 )
 
 if not get_option('no_shared')


### PR DESCRIPTION
Needed when the library isn't found in a default location, like is usually the case on Windows