### PR TITLE
Fix for MSVC builds

### DIFF
--- a/src/StretcherChannelData.cpp
+++ b/src/StretcherChannelData.cpp
@@ -29,6 +29,9 @@
 
 #include <algorithm>
 
+#undef min
+#undef max
+
 namespace RubberBand 
 {
       

--- a/src/StretcherImpl.cpp
+++ b/src/StretcherImpl.cpp
@@ -45,6 +45,9 @@
 #include <map>
 #include <algorithm>
 
+#undef min
+#undef max
+
 using namespace RubberBand;
 
 using std::cerr;

--- a/src/StretcherProcess.cpp
+++ b/src/StretcherProcess.cpp
@@ -42,6 +42,9 @@
 #include <deque>
 #include <algorithm>
 
+#undef min
+#undef max
+
 using namespace RubberBand;
 
 using std::cerr;

--- a/src/dsp/BQResampler.cpp
+++ b/src/dsp/BQResampler.cpp
@@ -33,6 +33,9 @@
 
 #define BQ_R__ R__
 
+#undef min
+#undef max
+
 using std::vector;
 using std::cerr;
 using std::endl;

--- a/src/dsp/Resampler.cpp
+++ b/src/dsp/Resampler.cpp
@@ -75,6 +75,9 @@
 
 #define BQ_R__ R__
 
+#undef min
+#undef max
+
 using namespace std;
 
 namespace RubberBand {


### PR DESCRIPTION
Using RubberBandSingle in a project, these changes required to build with MSVC, because windows.h includes min & max macros, which mess up std::min() and std::max().
(NOMINMAX define not sufficient, at least in the project)

