### PR TITLE
Fix Linux/ARM builds with gcc-8.3

### DIFF
--- a/src/common/Allocators.h
+++ b/src/common/Allocators.h
@@ -28,6 +28,7 @@
 
 #include <new> // for std::bad_alloc
 #include <stdlib.h>
+#include <stddef.h>
 
 #include <stdexcept>
 


### PR DESCRIPTION
This fixes `error: 'ptrdiff_t' does not name a type`
see  SYSTEM_DATA_TYPES(7)