### PR TITLE
Fix build type detection in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -432,11 +432,11 @@ ladspa_symbol_args = []
 lv2_symbol_args = []
 vamp_symbol_args = []
 
-if get_option('buildtype').startswith('release')
+if get_option('debug')
+  config_summary += { 'Build type': 'Debug' }
+else
   config_summary += { 'Build type': 'Release' }
   feature_defines += ['-DNO_THREAD_CHECKS', '-DNO_TIMING', '-DNDEBUG']
-else
-  config_summary += { 'Build type': 'Debug' }
 endif
 
 if system == 'darwin'


### PR DESCRIPTION
The original detection code mistakenly detects the build type as "Debug" when the `buildtype` is `plain`, even though `plain` actually disables debugging (see https://mesonbuild.com/Builtin-options.html#details-for-buildtype). It's better to instead check the `debug` option directly. 