### PR TITLE
README.md: correct FFTW licence terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ licences for some relevant library code are as follows, to the best of
 our knowledge. See also the file [COMPILING.md](COMPILING.md) for more
 details.
 
- * FFTW3 - GPL; proprietary licence needed for redistribution
+ * FFTW3 - GPL or proprietary non-free licence
  * Intel IPP - Proprietary; licence needed for redistribution
  * SLEEF - BSD-like
  * KissFFT - BSD-like


### PR DESCRIPTION
Other than currently stated in README.md FFTW3 does *not* require a commercial licence for redistribution as long as the terms of the GPL are met.

> FFTW is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version. 
> [...]
> Non-free versions of FFTW are available under terms different from those of the General Public License. (e.g. they do not require you to accompany any object code using FFTW with the corresponding source code.) For these alternative terms you must purchase a license from MIT’s Technology Licensing Office. Users interested in such a license should contact us (fftw@fftw.org) for more information.

See also https://fftw.org/doc/License-and-Copyright.html