### PR TITLE
Add Android cross-compilation support for Rubber Band static library.

### DIFF
--- a/cross/android.txt
+++ b/cross/android.txt
@@ -1,0 +1,21 @@
+[binaries]
+c = '/Users/joel/Library/Android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android34-clang'
+cpp = '/Users/joel/Library/Android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android34-clang++'
+ar = '/Users/joel/Library/Android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar'
+strip = '/Users/joel/Library/Android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-strip'
+pkg-config = '/usr/local/bin/pkg-config'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[built-in options]
+c_args = ['-DANDROID', '-fPIC']
+cpp_args = ['-DANDROID', '-fPIC']
+c_link_args = ['-fPIC']
+cpp_link_args = ['-fPIC']
+
+[properties]
+sys_root = '/Users/joel/Library/Android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/darwin-x86_64/sysroot'


### PR DESCRIPTION
This commit adds support for building the Rubber Band Library for Android (aarch64) using the Meson build system with cross-compilation via the Android NDK.

Key details:
- Uses KissFFT as the FFT backend
- Uses built-in resampler
- Builds only the static library (`librubberband.a`)
- Disables optional features not needed for Android builds:
  - JNI
  - Command-line utilities
  - Vamp plugin
  - LADSPA and LV2 plugins
  - Unit tests

Configuration is provided via a Meson cross file (`cross/android.txt`) targeting the Android NDK toolchain.

This setup enables integration of the Rubber Band Library into Android apps via native C++ code (e.g., through JNI or static linking in native libraries).
