### PR TITLE
Add RUBBERBAND_STATIC check to RubberBandLiveShifter.h

### DIFF
--- a/rubberband/RubberBandLiveShifter.h
+++ b/rubberband/RubberBandLiveShifter.h
@@ -30,7 +30,11 @@
 
 #undef RUBBERBAND_LIVE_DLLEXPORT
 #ifdef _MSC_VER
+#ifndef RUBBERBAND_STATIC
 #define RUBBERBAND_LIVE_DLLEXPORT __declspec(dllexport)
+#else
+#define RUBBERBAND_LIVE_DLLEXPORT
+#endif
 #else
 #define RUBBERBAND_LIVE_DLLEXPORT
 #endif


### PR DESCRIPTION
Prevents LiveShifter symbols from being exported when building statically on Windows, matching the pattern used in other rubberband headers.