### PR TITLE
Add missing `<stddef.h>`.

### DIFF
--- a/src/common/mathmisc.h
+++ b/src/common/mathmisc.h
@@ -24,6 +24,8 @@
 #ifndef RUBBERBAND_MATHMISC_H
 #define RUBBERBAND_MATHMISC_H
 
+#include <stddef.h>
+
 #include "sysutils.h"
 
 #ifndef M_PI


### PR DESCRIPTION
`mathmisc.h` uses `size_t` which needs `<stddef.h>`. This causes compilation failures on macOS 26.6.

Related: https://github.com/microsoft/vcpkg/pull/53316